### PR TITLE
Feature/jetstream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,6 @@
 			<version>2.11.5</version>
 		</dependency>
 		<dependency>
-			<groupId>org.projectlombok</groupId>
-			<artifactId>lombok</artifactId>
-			<version>1.18.20</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
 			<version>2.14.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>net.boomerangplatform</groupId>
+	<artifactId>lib-jetstream</artifactId>
+	<version>0.0.1</version>
+	<name>lib-jetstream</name>
+	<url>https://www.useboomerang.io</url>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>11</java.version>
+		<maven.compiler.source>${java.version}</maven.compiler.source>
+		<maven.compiler.target>${java.version}</maven.compiler.target>
+	</properties>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<version>5.3.9</version>
+		</dependency>
+		<dependency>
+			<groupId>io.nats</groupId>
+			<artifactId>jnats</artifactId>
+			<version>2.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<version>1.18.20</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.14.1</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.11</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<pluginManagement>
+			<!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+			<plugins>
+				<!-- clean lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#clean_Lifecycle -->
+				<plugin>
+					<artifactId>maven-clean-plugin</artifactId>
+					<version>3.1.0</version>
+				</plugin>
+				<!-- default lifecycle, jar packaging: see https://maven.apache.org/ref/current/maven-core/default-bindings.html#Plugin_bindings_for_jar_packaging -->
+				<plugin>
+					<artifactId>maven-resources-plugin</artifactId>
+					<version>3.0.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.8.0</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>2.22.1</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-jar-plugin</artifactId>
+					<version>3.0.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-install-plugin</artifactId>
+					<version>2.5.2</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-deploy-plugin</artifactId>
+					<version>2.8.2</version>
+				</plugin>
+				<!-- site lifecycle, see https://maven.apache.org/ref/current/maven-core/lifecycles.html#site_Lifecycle -->
+				<plugin>
+					<artifactId>maven-site-plugin</artifactId>
+					<version>3.7.1</version>
+				</plugin>
+				<plugin>
+					<artifactId>maven-project-info-reports-plugin</artifactId>
+					<version>3.0.0</version>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>net.boomerangplatform</groupId>
+	<groupId>io.boomerang</groupId>
 	<artifactId>lib-jetstream</artifactId>
 	<version>0.0.1</version>
 	<name>lib-jetstream</name>

--- a/pom.xml
+++ b/pom.xml
@@ -86,4 +86,12 @@
 			</plugins>
 		</pluginManagement>
 	</build>
+
+	<distributionManagement>
+		<repository>
+			<id>github</id>
+			<name>GitHub Boomerang Apache Maven Packages</name>
+			<url>https://maven.pkg.github.com/boomerang-io/flow.lib.streaming</url>
+		</repository>
+	</distributionManagement>
 </project>

--- a/src/main/java/io/boomerang/jetstream/ConnectionAutoConfiguration.java
+++ b/src/main/java/io/boomerang/jetstream/ConnectionAutoConfiguration.java
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
 import io.nats.client.Connection;
 import io.nats.client.ConnectionListener;
 import io.nats.client.Consumer;

--- a/src/main/java/io/boomerang/jetstream/ConnectionAutoConfiguration.java
+++ b/src/main/java/io/boomerang/jetstream/ConnectionAutoConfiguration.java
@@ -1,0 +1,67 @@
+package io.boomerang.jetstream;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import io.nats.client.Connection;
+import io.nats.client.ConnectionListener;
+import io.nats.client.Consumer;
+import io.nats.client.ErrorListener;
+import io.nats.client.Nats;
+import io.nats.client.Options;
+
+@Configuration
+class ConnectionAutoConfiguration {
+
+  private static final Logger logger = LogManager.getLogger(ConnectionAutoConfiguration.class);
+
+  @Autowired
+  Properties properties;
+
+  @Bean(destroyMethod = "close")
+  public Connection natsConnection() throws Exception {
+
+    logger.debug(
+        "Initializing a new NATS connection context with URL: " + properties.getJetstreamUrl());
+
+    // Define NATS connection and error listeners
+    ConnectionListener connectionListener = new ConnectionListener() {
+
+      @Override
+      public void connectionEvent(Connection conn, Events type) {
+        logger.debug("NATS connection event of type \"" + type + "\" on connection: " + conn);
+      }
+    };
+    ErrorListener errorListener = new ErrorListener() {
+
+      @Override
+      public void errorOccurred(Connection conn, String error) {
+        logger.error("A NATS error occurred \"" + error + "\" on connection: " + conn);
+      }
+
+      @Override
+      public void exceptionOccurred(Connection conn, Exception exp) {
+        logger.error("A NATS exception occurred on connection: " + conn, exp);
+      }
+
+      @Override
+      public void slowConsumerDetected(Connection conn, Consumer consumer) {
+        logger.debug("NATS detected a slow consumer [" + consumer + "] on connection: " + conn);
+      }
+    };
+
+    // @formatter:off
+    Options options = new Options.Builder()
+        .server(properties.getJetstreamUrl())
+        .connectionListener(connectionListener)
+        .errorListener(errorListener)
+        .reconnectWait(properties.getServerReconnectWaitTime())
+        .maxReconnects(properties.getServerMaxReconnectAttempts())
+        .build();
+    // @formatter:on
+
+    return Nats.connect(options);
+  }
+}

--- a/src/main/java/io/boomerang/jetstream/ConsumerManager.java
+++ b/src/main/java/io/boomerang/jetstream/ConsumerManager.java
@@ -35,13 +35,14 @@ class ConsumerManager {
     // @formatter:off
     ConsumerConfiguration consumerConfiguration = ConsumerConfiguration.builder()
         .durable(properties.getConsumerName())
+        .deliverSubject(properties.getConsumerDeliveryTarget())
         .deliverPolicy(properties.getConsumerDeliverPolicy())
-        .filterSubject(properties.getConsumerFilterSubject())
         .ackPolicy(properties.getConsumerAcknowledgmentPolicy())
         .ackWait(properties.getConsumerAcknowledgmentTimeout())
+        .replayPolicy(properties.getConsumerReplayPolicy())
+        .filterSubject(properties.getConsumerFilterSubject())
         .maxAckPending(properties.getConsumerMaxAcknowledgmentMessagesPending())
         .maxDeliver(properties.getConsumerMaxDeliverRetry())
-        .replayPolicy(properties.getConsumerReplayPolicy())
         .build();
     // @formatter:on
 

--- a/src/main/java/io/boomerang/jetstream/ConsumerManager.java
+++ b/src/main/java/io/boomerang/jetstream/ConsumerManager.java
@@ -1,0 +1,85 @@
+package io.boomerang.jetstream;
+
+import java.io.IOException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.JetStreamManagement;
+import io.nats.client.api.ConsumerConfiguration;
+import io.nats.client.api.ConsumerInfo;
+
+@Component
+class ConsumerManager {
+
+  private static final Logger logger = LogManager.getLogger(ConsumerManager.class);
+
+  @Autowired
+  Properties properties;
+
+  @Autowired
+  StreamManager streamManager;
+
+  /**
+   * This helper method creates and returns a new Jetstream consumer.
+   * 
+   * @category Helper method.
+   * @throws JetStreamApiException
+   * @throws IOException
+   * @return A new {@link io.nats.client.api.ConsumerInfo ConsumerInfo} object.
+   */
+  ConsumerInfo createNewConsumer(JetStreamManagement jetStreamManagement)
+      throws IOException, JetStreamApiException {
+
+    // @formatter:off
+    ConsumerConfiguration consumerConfiguration = ConsumerConfiguration.builder()
+        .durable(properties.getConsumerName())
+        .deliverPolicy(properties.getConsumerDeliverPolicy())
+        .filterSubject(properties.getConsumerFilterSubject())
+        .ackPolicy(properties.getConsumerAcknowledgmentPolicy())
+        .ackWait(properties.getConsumerAcknowledgmentTimeout())
+        .maxAckPending(properties.getConsumerMaxAcknowledgmentMessagesPending())
+        .maxDeliver(properties.getConsumerMaxDeliverRetry())
+        .replayPolicy(properties.getConsumerReplayPolicy())
+        .build();
+    // @formatter:on
+
+    // Create the Jetstream stream if this doesn't exist
+    if (!streamManager.streamExists(jetStreamManagement)) {
+      streamManager.createNewStream(jetStreamManagement);
+    }
+
+    // Create Jetstream consumer
+    logger.debug(
+        "Initializing a new Jetstream consumer with configuration: " + consumerConfiguration);
+
+    return jetStreamManagement.addOrUpdateConsumer(properties.getStreamName(),
+        consumerConfiguration);
+  }
+
+  ConsumerInfo getConsumerInfo(JetStreamManagement jetStreamManagement)
+      throws IOException, JetStreamApiException {
+
+    try {
+      return jetStreamManagement.getConsumerInfo(properties.getStreamName(),
+          properties.getConsumerName());
+    } catch (JetStreamApiException e) {
+
+      if (e.getErrorCode() == 404) {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  Boolean consumerExists(JetStreamManagement jetStreamManagement) {
+    try {
+      return getConsumerInfo(jetStreamManagement) != null;
+    } catch (Exception e) {
+      logger.error("An error occurred while retrieving Jetstream consumer information!", e);
+      return false;
+    }
+  }
+}

--- a/src/main/java/io/boomerang/jetstream/ConsumerType.java
+++ b/src/main/java/io/boomerang/jetstream/ConsumerType.java
@@ -1,0 +1,5 @@
+package io.boomerang.jetstream;
+
+public enum ConsumerType {
+  PushBased, PullBased;
+}

--- a/src/main/java/io/boomerang/jetstream/JetstreamClient.java
+++ b/src/main/java/io/boomerang/jetstream/JetstreamClient.java
@@ -2,7 +2,7 @@ package io.boomerang.jetstream;
 
 public interface JetstreamClient {
 
-  void publish(String subject, String message);
+  public void publish(String subject, String message);
 
-  void consume(String subject);
+  public Boolean subscribe(String subject, JetstreamMessageListener listener);
 }

--- a/src/main/java/io/boomerang/jetstream/JetstreamClient.java
+++ b/src/main/java/io/boomerang/jetstream/JetstreamClient.java
@@ -1,0 +1,8 @@
+package io.boomerang.jetstream;
+
+public interface JetstreamClient {
+
+  void publish(String subject, String message);
+
+  void consume(String subject);
+}

--- a/src/main/java/io/boomerang/jetstream/JetstreamClient.java
+++ b/src/main/java/io/boomerang/jetstream/JetstreamClient.java
@@ -2,7 +2,10 @@ package io.boomerang.jetstream;
 
 public interface JetstreamClient {
 
-  public void publish(String subject, String message);
+  public Boolean publish(String subject, String message);
 
-  public Boolean subscribe(String subject, JetstreamMessageListener listener);
+  public Boolean subscribe(String subject, ConsumerType consumerType,
+      JetstreamMessageListener listener);
+
+  public Boolean unsubscribe(String subject);
 }

--- a/src/main/java/io/boomerang/jetstream/JetstreamClient.java
+++ b/src/main/java/io/boomerang/jetstream/JetstreamClient.java
@@ -2,10 +2,49 @@ package io.boomerang.jetstream;
 
 public interface JetstreamClient {
 
+  /**
+   * Publish a new message to NATS Jetstream server.
+   * 
+   * <p>
+   * <b>Note:</b> When publishing a message, the framework will also create a new stream if this
+   * does not exist. Stream parameters are defined by the external properties. See readme for more
+   * information on properties.
+   * </p>
+   * 
+   * @param subject The subject of the message.
+   * @param message The message itself.
+   * 
+   * @return {@code Boolean} value indicating if the message was published successfully.
+   */
   public Boolean publish(String subject, String message);
 
+  /**
+   * Subscribe to receive new messages on the provided subject.
+   * 
+   * <p>
+   * <b>Note:</b> When subscribing to a subject, the framework will also create a new consumer of
+   * the provided type if this does not exist. Consumer parameters are defined by the external
+   * properties. See readme for more information on properties.
+   * </p>
+   * 
+   * @param subject The subscription subject.
+   * @param consumerType Consumer type. Can be {@link io.boomerang.jetstream.ConsumerType PushBased}
+   *        or {@link io.boomerang.jetstream.ConsumerType PullBased}.
+   * @param listener The {@link io.boomerang.jetstream.JetstreamMessageListener listener} for
+   *        incoming messages.
+   * @return {@code Boolean} value indicating if the subscription was successful.
+   * @see <a href="https://docs.nats.io/jetstream/concepts">NATS Jetstream Concepts</a>
+   * @see <a href="https://docs.nats.io/jetstream/concepts/consumers">About Consumers</a>
+   */
   public Boolean subscribe(String subject, ConsumerType consumerType,
       JetstreamMessageListener listener);
 
+  /**
+   * Unsubscribe from receiving new messages on the provided subject.
+   * 
+   * @param subject The subject to unsubscribe from.
+   * @return {@code Boolean} value indicating if the subscription was cancelled successfully.
+   *         Returns {@code false} if there is no active subscription on the subject.
+   */
   public Boolean unsubscribe(String subject);
 }

--- a/src/main/java/io/boomerang/jetstream/JetstreamClientImpl.java
+++ b/src/main/java/io/boomerang/jetstream/JetstreamClientImpl.java
@@ -1,17 +1,22 @@
 package io.boomerang.jetstream;
 
 import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import io.nats.client.Connection;
 import io.nats.client.Dispatcher;
-import io.nats.client.JetStream;
 import io.nats.client.JetStreamSubscription;
 import io.nats.client.Message;
 import io.nats.client.MessageHandler;
+import io.nats.client.PullSubscribeOptions;
 import io.nats.client.PushSubscribeOptions;
+import io.nats.client.Subscription;
 import io.nats.client.api.ConsumerInfo;
 import io.nats.client.api.PublishAck;
 import io.nats.client.impl.NatsMessage;
@@ -22,6 +27,9 @@ class JetstreamClientImpl implements JetstreamClient {
   private static final Logger logger = LogManager.getLogger(JetstreamClientImpl.class);
 
   @Autowired
+  private Properties properties;
+
+  @Autowired
   private Connection natsConnection;
 
   @Autowired
@@ -30,38 +38,99 @@ class JetstreamClientImpl implements JetstreamClient {
   @Autowired
   private ConsumerManager consumerManager;
 
-  private JetStream jetstreamContext;
+  private Map<String, Subscription> activeSubscriptions = new HashMap<>();
 
   @Override
-  public void publish(String subject, String message) {
+  public Boolean publish(String subject, String message) {
 
-    // Create the NATS message
-    // @formatter:off
-    Message natsMessage = NatsMessage.builder()
-        .subject(subject)
-        .data(message, StandardCharsets.UTF_8)
-        .build();
-    // @formatter:on
-
-    // Publish the message
     try {
-      PublishAck publishAck = getJetstreamContext().publish(natsMessage);
+      // Create the Jetstream stream if this doesn't exist
+      if (!streamManager.streamExists(natsConnection.jetStreamManagement())) {
+        streamManager.createNewStream(natsConnection.jetStreamManagement());
+      }
+
+      // Create the NATS message
+      // @formatter:off
+      Message natsMessage = NatsMessage.builder()
+          .subject(subject)
+          .data(message, StandardCharsets.UTF_8)
+          .build();
+      // @formatter:on
+
+      // Publish the message
+      PublishAck publishAck = natsConnection.jetStream().publish(natsMessage);
+
       logger.debug("Message published! " + publishAck);
+      return true;
+
     } catch (Exception e) {
-      logger.error("An error occurred publishing the message to NATS Jetstream server!", e);
+
+      logger.error("An error occurred while publishing the message to NATS Jetstream stream!", e);
+      return false;
     }
   }
 
   @Override
-  public Boolean subscribe(String subject, JetstreamMessageListener listener) {
+  public Boolean subscribe(String subject, ConsumerType consumerType,
+      JetstreamMessageListener listener) {
+
+    // Check if there is an active subscription
+    if (activeSubscriptions.get(subject) != null) {
+      logger.error("There is already an active subscription for subject \"" + subject
+          + "\". Please unsubscribe first!");
+      return false;
+    }
+
+    // Subscribe and add this subscription to active subscriptions if successful
+    try {
+      switch (consumerType) {
+        case PushBased:
+          activeSubscriptions.put(subject, pushBasedSubscription(subject, listener).orElseThrow());
+          break;
+        case PullBased:
+          activeSubscriptions.put(subject, pullBasedSubscription(subject, listener).orElseThrow());
+          break;
+      }
+
+      // Subscription successful
+      return true;
+    } catch (NoSuchElementException e) {
+
+      // Could not subscribe
+      return false;
+    }
+  }
+
+  @Override
+  public Boolean unsubscribe(String subject) {
+
+    // Check if there is an active subscription
+    if (activeSubscriptions.get(subject) == null) {
+      logger.error("There is no active subscription for subject \"" + subject + "\"!");
+      return false;
+    }
+
+    // Unsubscribe and remove the subscription from active subscriptions
+    activeSubscriptions.get(subject).unsubscribe();
+    activeSubscriptions.remove(subject);
+
+    logger.debug("Unsubscribed from events with subject \"" + subject + "\"!");
+
+    return true;
+  };
+
+  private Optional<Subscription> pushBasedSubscription(String subject,
+      JetstreamMessageListener listener) {
 
     try {
-      ConsumerInfo consumerInfo =
-          consumerManager.getConsumerInfo(natsConnection.jetStreamManagement());
+      // Get push-based consumer first
+      ConsumerInfo consumerInfo = consumerManager
+          .getConsumerInfo(natsConnection.jetStreamManagement(), ConsumerType.PushBased);
 
       // Create the Jetstream consumer if this doesn't exist
       if (consumerInfo == null) {
-        consumerInfo = consumerManager.createNewConsumer(natsConnection.jetStreamManagement());
+        consumerInfo = consumerManager.createNewConsumer(natsConnection.jetStreamManagement(),
+            ConsumerType.PushBased);
       }
 
       // Create a dispatcher without a default handler and the push subscription options
@@ -69,48 +138,87 @@ class JetstreamClientImpl implements JetstreamClient {
       PushSubscribeOptions options =
           PushSubscribeOptions.builder().durable(consumerInfo.getName()).build();
 
-      // Create our message handler
+      // Create the message handler
       MessageHandler handler = (message) -> {
         String data = new String(message.getData());
         listener.newMessageReceived(message.getSubject(), data);
         message.ack();
       };
 
+      // Subscribe to receive messages on subject and return this subscription
       JetStreamSubscription subscription =
           natsConnection.jetStream().subscribe(subject, dispatcher, handler, false, options);
-
       logger.debug("Successfully subscribed to NATS Jetstream consumer! " + subscription);
+      return Optional.of(subscription);
 
-      return true;
     } catch (Exception e) {
 
       logger.error("An error occurred while subscribing to NATS Jetstream consumer!", e);
-
-      return false;
+      return Optional.empty();
     }
   }
 
-  /**
-   * Lazy instantiates and returns a new {@link io.nats.client.JetStream JetStream} connection
-   * context.
-   * 
-   * @category Getter method.
-   */
-  private JetStream getJetstreamContext() {
+  private Optional<Subscription> pullBasedSubscription(String subject,
+      JetstreamMessageListener listener) {
 
-    if (this.jetstreamContext == null) {
-      try {
-        // Create new Jetstream connection context
-        this.jetstreamContext = natsConnection.jetStream();
+    try {
+      // Get pull-based consumer first
+      ConsumerInfo consumerInfo = consumerManager
+          .getConsumerInfo(natsConnection.jetStreamManagement(), ConsumerType.PullBased);
 
-        // Create the Jetstream stream if this doesn't exist
-        if (!streamManager.streamExists(natsConnection.jetStreamManagement())) {
-          streamManager.createNewStream(natsConnection.jetStreamManagement());
-        }
-      } catch (Exception e) {
-        logger.error("An error occurred while connecting to NATS Jetstream server!", e);
+      // Create the Jetstream consumer if this doesn't exist
+      if (consumerInfo == null) {
+        consumerInfo = consumerManager.createNewConsumer(natsConnection.jetStreamManagement(),
+            ConsumerType.PullBased);
       }
+
+      // Create pull subscription options and subscriber itself
+      PullSubscribeOptions options =
+          PullSubscribeOptions.builder().durable(consumerInfo.getName()).build();
+      JetStreamSubscription subscription = natsConnection.jetStream().subscribe(subject, options);
+
+      Thread handlerThread = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          logger.debug("Handler thread for Jetstream pull-based consumer is running...");
+
+          while (true) {
+            try {
+
+              // Get new message (if any, otherwise wait), then send it to the listener handler
+              subscription
+                  .iterate(properties.getConsumerPullBatchSize(),
+                      properties.getConsumerPullBatchFirstMessageWait())
+                  .forEachRemaining(message -> {
+
+                    logger.debug(
+                        "Handler thread for Jetstream pull-based consumer received a new message: "
+                            + message);
+
+                    if (message != null) {
+                      String data = new String(message.getData());
+                      listener.newMessageReceived(message.getSubject(), data);
+                      message.ack();
+                    }
+                  });
+            } catch (IllegalStateException e) {
+              logger.info(
+                  "Handler thread for Jetstream pull-based consumer subscription with subject \""
+                      + subject + "\" stopped!");
+              return;
+            }
+          }
+        }
+      });
+
+      handlerThread.start();
+      logger.debug("Successfully subscribed to NATS Jetstream consumer! " + subscription);
+      return Optional.of(subscription);
+
+    } catch (Exception e) {
+
+      logger.error("An error occurred while subscribing to NATS Jetstream consumer!", e);
+      return Optional.empty();
     }
-    return this.jetstreamContext;
   }
 }

--- a/src/main/java/io/boomerang/jetstream/JetstreamClientImpl.java
+++ b/src/main/java/io/boomerang/jetstream/JetstreamClientImpl.java
@@ -1,0 +1,75 @@
+package io.boomerang.jetstream;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import io.nats.client.Connection;
+import io.nats.client.JetStream;
+import io.nats.client.Message;
+import io.nats.client.api.PublishAck;
+import io.nats.client.impl.NatsMessage;
+
+@Component
+class JetstreamClientImpl implements JetstreamClient {
+
+  private static final Logger logger = LogManager.getLogger(JetstreamClientImpl.class);
+
+  @Autowired
+  private Connection natsConnection;
+
+  @Autowired
+  private StreamManager streamManager;
+
+  private JetStream jetstreamContext;
+
+  @Override
+  public void publish(String subject, String message) {
+
+    // Create the NATS message
+    // @formatter:off
+    Message natsMessage = NatsMessage.builder()
+        .subject(subject)
+        .data(message, StandardCharsets.UTF_8)
+        .build();
+    // @formatter:on
+
+    // Publish the message
+    try {
+      PublishAck publishAck = getJetstreamContext().publish(natsMessage);
+      logger.debug("Message published! " + publishAck);
+    } catch (Exception e) {
+      logger.error("An error occurred publishing the message to NATS Jetstream server!", e);
+    }
+  }
+
+  @Override
+  public void consume(String subject) {
+    // TODO Auto-generated method stub
+  }
+
+  /**
+   * Lazy instantiates and returns a new {@link io.nats.client.JetStream JetStream} connection
+   * context.
+   * 
+   * @category Getter method.
+   */
+  private JetStream getJetstreamContext() {
+
+    if (this.jetstreamContext == null) {
+      try {
+        // Create new Jetstream connection context
+        this.jetstreamContext = natsConnection.jetStream();
+
+        // Create the Jetstream stream if this doesn't exist
+        if (!streamManager.streamExists(natsConnection.jetStreamManagement())) {
+          streamManager.createNewStream(natsConnection.jetStreamManagement());
+        }
+      } catch (Exception e) {
+        logger.error("An error occurred while connecting to NATS Jetstream server!", e);
+      }
+    }
+    return this.jetstreamContext;
+  }
+}

--- a/src/main/java/io/boomerang/jetstream/JetstreamClientImpl.java
+++ b/src/main/java/io/boomerang/jetstream/JetstreamClientImpl.java
@@ -4,10 +4,16 @@ import java.nio.charset.StandardCharsets;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.codec.EncodingException;
 import org.springframework.stereotype.Component;
 import io.nats.client.Connection;
+import io.nats.client.Dispatcher;
 import io.nats.client.JetStream;
+import io.nats.client.JetStreamSubscription;
 import io.nats.client.Message;
+import io.nats.client.MessageHandler;
+import io.nats.client.PushSubscribeOptions;
+import io.nats.client.api.ConsumerInfo;
 import io.nats.client.api.PublishAck;
 import io.nats.client.impl.NatsMessage;
 
@@ -21,6 +27,9 @@ class JetstreamClientImpl implements JetstreamClient {
 
   @Autowired
   private StreamManager streamManager;
+
+  @Autowired
+  private ConsumerManager consumerManager;
 
   private JetStream jetstreamContext;
 
@@ -45,8 +54,45 @@ class JetstreamClientImpl implements JetstreamClient {
   }
 
   @Override
-  public void consume(String subject) {
-    // TODO Auto-generated method stub
+  public Boolean subscribe(String subject, JetstreamMessageListener listener) {
+
+    try {
+      ConsumerInfo consumerInfo =
+          consumerManager.getConsumerInfo(natsConnection.jetStreamManagement());
+
+      // Create the Jetstream consumer if this doesn't exist
+      if (consumerInfo == null) {
+        consumerInfo = consumerManager.createNewConsumer(natsConnection.jetStreamManagement());
+      }
+
+      // Create a dispatcher without a default handler and the push subscription options
+      Dispatcher dispatcher = natsConnection.createDispatcher();
+      PushSubscribeOptions options =
+          PushSubscribeOptions.builder().durable(consumerInfo.getName()).build();
+
+      // Create our message handler
+      MessageHandler handler = (message) -> {
+
+        if (message.isUtf8mode()) {
+          String data = new String(message.getData());
+          listener.newMessageReceived(data);
+        } else {
+          throw new EncodingException("Message is not an UTF-8 encoded string!:" + message);
+        }
+      };
+
+      JetStreamSubscription subscription =
+          natsConnection.jetStream().subscribe(subject, dispatcher, handler, true, options);
+
+      logger.debug("Successfully subscriber to NATS Jetstream consumer! " + subscription);
+
+      return true;
+    } catch (Exception e) {
+
+      logger.error("An error occurred while subscribing to NATS Jetstream consumer!", e);
+
+      return false;
+    }
   }
 
   /**

--- a/src/main/java/io/boomerang/jetstream/JetstreamMessageListener.java
+++ b/src/main/java/io/boomerang/jetstream/JetstreamMessageListener.java
@@ -1,0 +1,6 @@
+package io.boomerang.jetstream;
+
+public interface JetstreamMessageListener {
+
+  public void newMessageReceived(String message);
+}

--- a/src/main/java/io/boomerang/jetstream/JetstreamMessageListener.java
+++ b/src/main/java/io/boomerang/jetstream/JetstreamMessageListener.java
@@ -2,5 +2,5 @@ package io.boomerang.jetstream;
 
 public interface JetstreamMessageListener {
 
-  public void newMessageReceived(String message);
+  public void newMessageReceived(String subject, String message);
 }

--- a/src/main/java/io/boomerang/jetstream/JetstreamMessageListener.java
+++ b/src/main/java/io/boomerang/jetstream/JetstreamMessageListener.java
@@ -2,5 +2,11 @@ package io.boomerang.jetstream;
 
 public interface JetstreamMessageListener {
 
+  /**
+   * Invoked when receiving a new message from NATS Jetstream server.
+   * 
+   * @param subject The subject of the new message.
+   * @param message The message.
+   */
   public void newMessageReceived(String subject, String message);
 }

--- a/src/main/java/io/boomerang/jetstream/Properties.java
+++ b/src/main/java/io/boomerang/jetstream/Properties.java
@@ -74,11 +74,11 @@ class Properties {
   @Value("${eventing.jetstream.consumer.name}")
   private String consumerName;
 
+  @Value("${eventing.jetstream.consumer.delivery-target}")
+  private String consumerDeliveryTarget;
+
   @Value("${eventing.jetstream.consumer.deliver-policy:All}")
   private DeliverPolicy consumerDeliverPolicy;
-
-  @Value("${eventing.jetstream.consumer.filter-subject:#{null}}")
-  private String consumerFilterSubject;
 
   @Value("${eventing.jetstream.consumer.acknowledgment-policy:Explicit}")
   private AckPolicy consumerAcknowledgmentPolicy;
@@ -86,15 +86,15 @@ class Properties {
   @Value("${eventing.jetstream.consumer.acknowledgment-timeout:30s}")
   private Duration consumerAcknowledgmentTimeout;
 
+  @Value("${eventing.jetstream.consumer.replay-policy:Instant}")
+  private ReplayPolicy consumerReplayPolicy;
+
+  @Value("${eventing.jetstream.consumer.filter-subject:#{null}}")
+  private String consumerFilterSubject;
+
   @Value("${eventing.jetstream.consumer.max-acknowledgment-messages-pending:0}")
   private Long consumerMaxAcknowledgmentMessagesPending;
 
   @Value("${eventing.jetstream.consumer.max-deliver-retry:-1}")
   private Long consumerMaxDeliverRetry;
-
-  @Value("${eventing.jetstream.consumer.replay-policy:Instant}")
-  private ReplayPolicy consumerReplayPolicy;
-
-  // @Value("${eventing.jetstream.consumer.new-messages-heartbeat:5s}")
-  // private Duration consumerNewMessagesHeartbeat;
 }

--- a/src/main/java/io/boomerang/jetstream/Properties.java
+++ b/src/main/java/io/boomerang/jetstream/Properties.java
@@ -10,11 +10,8 @@ import io.nats.client.api.DiscardPolicy;
 import io.nats.client.api.ReplayPolicy;
 import io.nats.client.api.RetentionPolicy;
 import io.nats.client.api.StorageType;
-import lombok.AccessLevel;
-import lombok.Getter;
 
 @Component
-@Getter(AccessLevel.PACKAGE)
 class Properties {
 
   // NATS Jetstream server properties
@@ -69,32 +66,210 @@ class Properties {
   @Value("${eventing.jetstream.stream.duplicate-window:0ms}")
   private Duration streamDuplicateWindow;
 
-  // NATS Jetstream consumer properties
+  // NATS Jetstream push-based consumer properties
 
-  @Value("${eventing.jetstream.consumer.name}")
-  private String consumerName;
+  @Value("${eventing.jetstream.consumer.push.name}")
+  private String consumerPushName;
 
-  @Value("${eventing.jetstream.consumer.delivery-target}")
-  private String consumerDeliveryTarget;
+  @Value("${eventing.jetstream.consumer.push.acknowledgment-policy:None}")
+  private AckPolicy consumerPushAcknowledgmentPolicy;
 
-  @Value("${eventing.jetstream.consumer.deliver-policy:All}")
-  private DeliverPolicy consumerDeliverPolicy;
+  @Value("${eventing.jetstream.consumer.push.acknowledgment-wait:30s}")
+  private Duration consumerPushAcknowledgmentWait;
 
-  @Value("${eventing.jetstream.consumer.acknowledgment-policy:Explicit}")
-  private AckPolicy consumerAcknowledgmentPolicy;
+  @Value("${eventing.jetstream.consumer.push.deliver-policy:All}")
+  private DeliverPolicy consumerPushDeliverPolicy;
 
-  @Value("${eventing.jetstream.consumer.acknowledgment-timeout:30s}")
-  private Duration consumerAcknowledgmentTimeout;
+  @Value("${eventing.jetstream.consumer.push.delivery-subject}")
+  private String consumerPushDeliverySubject;
 
-  @Value("${eventing.jetstream.consumer.replay-policy:Instant}")
-  private ReplayPolicy consumerReplayPolicy;
+  @Value("${eventing.jetstream.consumer.push.filter-subject:#{null}}")
+  private String consumerPushFilterSubject;
 
-  @Value("${eventing.jetstream.consumer.filter-subject:#{null}}")
-  private String consumerFilterSubject;
+  @Value("${eventing.jetstream.consumer.push.max-acknowledgments-pending:0}")
+  private Long consumerPushMaxAcknowledgmentsPending;
 
-  @Value("${eventing.jetstream.consumer.max-acknowledgment-messages-pending:0}")
-  private Long consumerMaxAcknowledgmentMessagesPending;
+  @Value("${eventing.jetstream.consumer.push.max-deliver-retry:-1}")
+  private Long consumerPushMaxDeliverRetry;
 
-  @Value("${eventing.jetstream.consumer.max-deliver-retry:-1}")
-  private Long consumerMaxDeliverRetry;
+  @Value("${eventing.jetstream.consumer.push.replay-policy:Instant}")
+  private ReplayPolicy consumerPushReplayPolicy;
+
+  // NATS Jetstream pull-based consumer properties
+
+  @Value("${eventing.jetstream.consumer.pull.name}")
+  private String consumerPullName;
+
+  @Value("${eventing.jetstream.consumer.pull.acknowledgment-policy:Explicit}")
+  private AckPolicy consumerPullAcknowledgmentPolicy;
+
+  @Value("${eventing.jetstream.consumer.pull.acknowledgment-wait:30s}")
+  private Duration consumerPullAcknowledgmentWait;
+
+  @Value("${eventing.jetstream.consumer.pull.deliver-policy:All}")
+  private DeliverPolicy consumerPullDeliverPolicy;
+
+  @Value("${eventing.jetstream.consumer.pull.filter-subject:#{null}}")
+  private String consumerPullFilterSubject;
+
+  @Value("${eventing.jetstream.consumer.pull.max-acknowledgments-pending:0}")
+  private Long consumerPullMaxAcknowledgmentsPending;
+
+  @Value("${eventing.jetstream.consumer.pull.max-deliver-retry:-1}")
+  private Long consumerPullMaxDeliverRetry;
+
+  @Value("${eventing.jetstream.consumer.pull.replay-policy:Instant}")
+  private ReplayPolicy consumerPullReplayPolicy;
+
+  @Value("${eventing.jetstream.consumer.pull.batch-size:10}")
+  private Integer consumerPullBatchSize;
+
+  @Value("${eventing.jetstream.consumer.pull.batch-first-message-wait:30s}")
+  private Duration consumerPullBatchFirstMessageWait;
+
+  // Property getters (auto-generated)
+
+  public String getJetstreamUrl() {
+    return this.jetstreamUrl;
+  }
+
+  public Duration getServerReconnectWaitTime() {
+    return this.serverReconnectWaitTime;
+  }
+
+  public Integer getServerMaxReconnectAttempts() {
+    return this.serverMaxReconnectAttempts;
+  }
+
+  public String getStreamName() {
+    return this.streamName;
+  }
+
+  public StorageType getStreamStorageType() {
+    return this.streamStorageType;
+  }
+
+  public List<String> getStreamSubjects() {
+    return this.streamSubjects;
+  }
+
+  public Integer getStreamReplicas() {
+    return this.streamReplicas;
+  }
+
+  public Duration getStreamMessageMaxAge() {
+    return this.streamMessageMaxAge;
+  }
+
+  public Long getStreamMaxBytes() {
+    return this.streamMaxBytes;
+  }
+
+  public Long getStreamMaxMessages() {
+    return this.streamMaxMessages;
+  }
+
+  public Long getStreamMaxMessageSize() {
+    return this.streamMaxMessageSize;
+  }
+
+  public Long getStreamMaxConsumers() {
+    return this.streamMaxConsumers;
+  }
+
+  public Boolean getStreamNoAcknowledgment() {
+    return this.streamNoAcknowledgment;
+  }
+
+  public Boolean isStreamNoAcknowledgment() {
+    return this.streamNoAcknowledgment;
+  }
+
+  public RetentionPolicy getStreamRetentionPolicy() {
+    return this.streamRetentionPolicy;
+  }
+
+  public DiscardPolicy getStreamDiscardPolicy() {
+    return this.streamDiscardPolicy;
+  }
+
+  public Duration getStreamDuplicateWindow() {
+    return this.streamDuplicateWindow;
+  }
+
+  public String getConsumerPushName() {
+    return this.consumerPushName;
+  }
+
+  public AckPolicy getConsumerPushAcknowledgmentPolicy() {
+    return this.consumerPushAcknowledgmentPolicy;
+  }
+
+  public Duration getConsumerPushAcknowledgmentWait() {
+    return this.consumerPushAcknowledgmentWait;
+  }
+
+  public DeliverPolicy getConsumerPushDeliverPolicy() {
+    return this.consumerPushDeliverPolicy;
+  }
+
+  public String getConsumerPushDeliverySubject() {
+    return this.consumerPushDeliverySubject;
+  }
+
+  public String getConsumerPushFilterSubject() {
+    return this.consumerPushFilterSubject;
+  }
+
+  public Long getConsumerPushMaxAcknowledgmentsPending() {
+    return this.consumerPushMaxAcknowledgmentsPending;
+  }
+
+  public Long getConsumerPushMaxDeliverRetry() {
+    return this.consumerPushMaxDeliverRetry;
+  }
+
+  public ReplayPolicy getConsumerPushReplayPolicy() {
+    return this.consumerPushReplayPolicy;
+  }
+
+  public String getConsumerPullName() {
+    return this.consumerPullName;
+  }
+
+  public AckPolicy getConsumerPullAcknowledgmentPolicy() {
+    return this.consumerPullAcknowledgmentPolicy;
+  }
+
+  public Duration getConsumerPullAcknowledgmentWait() {
+    return this.consumerPullAcknowledgmentWait;
+  }
+
+  public DeliverPolicy getConsumerPullDeliverPolicy() {
+    return this.consumerPullDeliverPolicy;
+  }
+
+  public String getConsumerPullFilterSubject() {
+    return this.consumerPullFilterSubject;
+  }
+
+  public Long getConsumerPullMaxAcknowledgmentsPending() {
+    return this.consumerPullMaxAcknowledgmentsPending;
+  }
+
+  public Long getConsumerPullMaxDeliverRetry() {
+    return this.consumerPullMaxDeliverRetry;
+  }
+
+  public ReplayPolicy getConsumerPullReplayPolicy() {
+    return this.consumerPullReplayPolicy;
+  }
+
+  public Integer getConsumerPullBatchSize() {
+    return this.consumerPullBatchSize;
+  }
+
+  public Duration getConsumerPullBatchFirstMessageWait() {
+    return this.consumerPullBatchFirstMessageWait;
+  }
 }

--- a/src/main/java/io/boomerang/jetstream/Properties.java
+++ b/src/main/java/io/boomerang/jetstream/Properties.java
@@ -1,0 +1,64 @@
+package io.boomerang.jetstream;
+
+import java.time.Duration;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import io.nats.client.api.DiscardPolicy;
+import io.nats.client.api.RetentionPolicy;
+import io.nats.client.api.StorageType;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Component
+@Getter(AccessLevel.PACKAGE)
+class Properties {
+
+  @Value("${eventing.jetstream.server.url}")
+  private String jetstreamUrl;
+
+  @Value("${eventing.jetstream.server.reconnect-wait-time:10s}")
+  private Duration serverReconnectWaitTime;
+
+  @Value("${eventing.jetstream.server.reconnect-max-attempts:-1}")
+  private Integer serverMaxReconnectAttempts;
+
+  @Value("${eventing.jetstream.stream.name}")
+  private String streamName;
+
+  @Value("${eventing.jetstream.stream.storage-type:Memory}")
+  private StorageType storageType;
+
+  @Value("#{\"${eventing.jetstream.stream.subjects}\".split(\",\")}")
+  private List<String> subjects;
+
+  @Value("${eventing.jetstream.stream.replicas:1}")
+  private Integer replicas;
+
+  @Value("${eventing.jetstream.stream.message-max-age:30d}")
+  private Duration messageMaxAge;
+
+  @Value("${eventing.jetstream.stream.max-bytes:-1}")
+  private Long maxBytes;
+
+  @Value("${eventing.jetstream.stream.max-messages:-1}")
+  private Long maxMessages;
+
+  @Value("${eventing.jetstream.stream.max-message-size:-1}")
+  private Long maxMessageSize;
+
+  @Value("${eventing.jetstream.stream.max-consumers:-1}")
+  private Long maxConsumers;
+
+  @Value("${eventing.jetstream.stream.no-acknowledgment:false}")
+  private Boolean noAcknowledgment;
+
+  @Value("${eventing.jetstream.stream.retention-policy:Limits}")
+  private RetentionPolicy retentionPolicy;
+
+  @Value("${eventing.jetstream.stream.discard-policy:Old}")
+  private DiscardPolicy discardPolicy;
+
+  @Value("${eventing.jetstream.stream.duplicate-window:0ms}")
+  private Duration duplicateWindow;
+}

--- a/src/main/java/io/boomerang/jetstream/Properties.java
+++ b/src/main/java/io/boomerang/jetstream/Properties.java
@@ -19,7 +19,7 @@ class Properties {
   @Value("${eventing.jetstream.server.url}")
   private String jetstreamUrl;
 
-  @Value("${eventing.jetstream.server.reconnect-wait-time:10s}")
+  @Value("#{T(java.time.Duration).parse('${eventing.jetstream.server.reconnect-wait-time:PT10S}')}")
   private Duration serverReconnectWaitTime;
 
   @Value("${eventing.jetstream.server.reconnect-max-attempts:-1}")
@@ -39,7 +39,7 @@ class Properties {
   @Value("${eventing.jetstream.stream.replicas:1}")
   private Integer streamReplicas;
 
-  @Value("${eventing.jetstream.stream.message-max-age:30d}")
+  @Value("#{T(java.time.Duration).parse('${eventing.jetstream.stream.message-max-age:P30D}')}")
   private Duration streamMessageMaxAge;
 
   @Value("${eventing.jetstream.stream.max-bytes:-1}")
@@ -63,7 +63,7 @@ class Properties {
   @Value("${eventing.jetstream.stream.discard-policy:Old}")
   private DiscardPolicy streamDiscardPolicy;
 
-  @Value("${eventing.jetstream.stream.duplicate-window:0ms}")
+  @Value("#{T(java.time.Duration).parse('${eventing.jetstream.stream.duplicate-window:PT0.0S}')}")
   private Duration streamDuplicateWindow;
 
   // NATS Jetstream push-based consumer properties
@@ -74,7 +74,7 @@ class Properties {
   @Value("${eventing.jetstream.consumer.push.acknowledgment-policy:None}")
   private AckPolicy consumerPushAcknowledgmentPolicy;
 
-  @Value("${eventing.jetstream.consumer.push.acknowledgment-wait:30s}")
+  @Value("#{T(java.time.Duration).parse('${eventing.jetstream.consumer.push.acknowledgment-wait:PT30S}')}")
   private Duration consumerPushAcknowledgmentWait;
 
   @Value("${eventing.jetstream.consumer.push.deliver-policy:All}")
@@ -103,7 +103,7 @@ class Properties {
   @Value("${eventing.jetstream.consumer.pull.acknowledgment-policy:Explicit}")
   private AckPolicy consumerPullAcknowledgmentPolicy;
 
-  @Value("${eventing.jetstream.consumer.pull.acknowledgment-wait:30s}")
+  @Value("#{T(java.time.Duration).parse('${eventing.jetstream.consumer.pull.acknowledgment-wait:PT30S}')}")
   private Duration consumerPullAcknowledgmentWait;
 
   @Value("${eventing.jetstream.consumer.pull.deliver-policy:All}")
@@ -124,7 +124,7 @@ class Properties {
   @Value("${eventing.jetstream.consumer.pull.batch-size:10}")
   private Integer consumerPullBatchSize;
 
-  @Value("${eventing.jetstream.consumer.pull.batch-first-message-wait:30s}")
+  @Value("#{T(java.time.Duration).parse('${eventing.jetstream.consumer.pull.batch-first-message-wait:PT30S}')}")
   private Duration consumerPullBatchFirstMessageWait;
 
   // Property getters (auto-generated)

--- a/src/main/java/io/boomerang/jetstream/Properties.java
+++ b/src/main/java/io/boomerang/jetstream/Properties.java
@@ -4,7 +4,10 @@ import java.time.Duration;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import io.nats.client.api.AckPolicy;
+import io.nats.client.api.DeliverPolicy;
 import io.nats.client.api.DiscardPolicy;
+import io.nats.client.api.ReplayPolicy;
 import io.nats.client.api.RetentionPolicy;
 import io.nats.client.api.StorageType;
 import lombok.AccessLevel;
@@ -13,6 +16,8 @@ import lombok.Getter;
 @Component
 @Getter(AccessLevel.PACKAGE)
 class Properties {
+
+  // NATS Jetstream server properties
 
   @Value("${eventing.jetstream.server.url}")
   private String jetstreamUrl;
@@ -23,42 +28,73 @@ class Properties {
   @Value("${eventing.jetstream.server.reconnect-max-attempts:-1}")
   private Integer serverMaxReconnectAttempts;
 
+  // NATS Jetstream stream properties
+
   @Value("${eventing.jetstream.stream.name}")
   private String streamName;
 
   @Value("${eventing.jetstream.stream.storage-type:Memory}")
-  private StorageType storageType;
+  private StorageType streamStorageType;
 
   @Value("#{\"${eventing.jetstream.stream.subjects}\".split(\",\")}")
-  private List<String> subjects;
+  private List<String> streamSubjects;
 
   @Value("${eventing.jetstream.stream.replicas:1}")
-  private Integer replicas;
+  private Integer streamReplicas;
 
   @Value("${eventing.jetstream.stream.message-max-age:30d}")
-  private Duration messageMaxAge;
+  private Duration streamMessageMaxAge;
 
   @Value("${eventing.jetstream.stream.max-bytes:-1}")
-  private Long maxBytes;
+  private Long streamMaxBytes;
 
   @Value("${eventing.jetstream.stream.max-messages:-1}")
-  private Long maxMessages;
+  private Long streamMaxMessages;
 
   @Value("${eventing.jetstream.stream.max-message-size:-1}")
-  private Long maxMessageSize;
+  private Long streamMaxMessageSize;
 
   @Value("${eventing.jetstream.stream.max-consumers:-1}")
-  private Long maxConsumers;
+  private Long streamMaxConsumers;
 
   @Value("${eventing.jetstream.stream.no-acknowledgment:false}")
-  private Boolean noAcknowledgment;
+  private Boolean streamNoAcknowledgment;
 
   @Value("${eventing.jetstream.stream.retention-policy:Limits}")
-  private RetentionPolicy retentionPolicy;
+  private RetentionPolicy streamRetentionPolicy;
 
   @Value("${eventing.jetstream.stream.discard-policy:Old}")
-  private DiscardPolicy discardPolicy;
+  private DiscardPolicy streamDiscardPolicy;
 
   @Value("${eventing.jetstream.stream.duplicate-window:0ms}")
-  private Duration duplicateWindow;
+  private Duration streamDuplicateWindow;
+
+  // NATS Jetstream consumer properties
+
+  @Value("${eventing.jetstream.consumer.name}")
+  private String consumerName;
+
+  @Value("${eventing.jetstream.consumer.deliver-policy:All}")
+  private DeliverPolicy consumerDeliverPolicy;
+
+  @Value("${eventing.jetstream.consumer.filter-subject:#{null}}")
+  private String consumerFilterSubject;
+
+  @Value("${eventing.jetstream.consumer.acknowledgment-policy:Explicit}")
+  private AckPolicy consumerAcknowledgmentPolicy;
+
+  @Value("${eventing.jetstream.consumer.acknowledgment-timeout:30s}")
+  private Duration consumerAcknowledgmentTimeout;
+
+  @Value("${eventing.jetstream.consumer.max-acknowledgment-messages-pending:0}")
+  private Long consumerMaxAcknowledgmentMessagesPending;
+
+  @Value("${eventing.jetstream.consumer.max-deliver-retry:-1}")
+  private Long consumerMaxDeliverRetry;
+
+  @Value("${eventing.jetstream.consumer.replay-policy:Instant}")
+  private ReplayPolicy consumerReplayPolicy;
+
+  // @Value("${eventing.jetstream.consumer.new-messages-heartbeat:5s}")
+  // private Duration consumerNewMessagesHeartbeat;
 }

--- a/src/main/java/io/boomerang/jetstream/Properties.java
+++ b/src/main/java/io/boomerang/jetstream/Properties.java
@@ -1,7 +1,6 @@
 package io.boomerang.jetstream;
 
 import java.time.Duration;
-import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import io.nats.client.api.AckPolicy;
@@ -33,8 +32,8 @@ class Properties {
   @Value("${eventing.jetstream.stream.storage-type:Memory}")
   private StorageType streamStorageType;
 
-  @Value("#{\"${eventing.jetstream.stream.subjects}\".split(\",\")}")
-  private List<String> streamSubjects;
+  @Value("${eventing.jetstream.stream.subject}")
+  private String streamSubject;
 
   @Value("${eventing.jetstream.stream.replicas:1}")
   private Integer streamReplicas;
@@ -149,8 +148,8 @@ class Properties {
     return this.streamStorageType;
   }
 
-  public List<String> getStreamSubjects() {
-    return this.streamSubjects;
+  public String getStreamSubject() {
+    return this.streamSubject;
   }
 
   public Integer getStreamReplicas() {

--- a/src/main/java/io/boomerang/jetstream/Properties.java
+++ b/src/main/java/io/boomerang/jetstream/Properties.java
@@ -74,7 +74,7 @@ class Properties {
   @Value("${eventing.jetstream.consumer.push.acknowledgment-policy:None}")
   private AckPolicy consumerPushAcknowledgmentPolicy;
 
-  @Value("#{T(java.time.Duration).parse('${eventing.jetstream.consumer.push.acknowledgment-wait:PT30S}')}")
+  @Value("#{T(java.time.Duration).parse('${eventing.jetstream.consumer.push.acknowledgment-wait:PT1M}')}")
   private Duration consumerPushAcknowledgmentWait;
 
   @Value("${eventing.jetstream.consumer.push.deliver-policy:All}")
@@ -103,7 +103,7 @@ class Properties {
   @Value("${eventing.jetstream.consumer.pull.acknowledgment-policy:Explicit}")
   private AckPolicy consumerPullAcknowledgmentPolicy;
 
-  @Value("#{T(java.time.Duration).parse('${eventing.jetstream.consumer.pull.acknowledgment-wait:PT30S}')}")
+  @Value("#{T(java.time.Duration).parse('${eventing.jetstream.consumer.pull.acknowledgment-wait:PT1M}')}")
   private Duration consumerPullAcknowledgmentWait;
 
   @Value("${eventing.jetstream.consumer.pull.deliver-policy:All}")

--- a/src/main/java/io/boomerang/jetstream/StreamManager.java
+++ b/src/main/java/io/boomerang/jetstream/StreamManager.java
@@ -1,0 +1,78 @@
+package io.boomerang.jetstream;
+
+import java.io.IOException;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import io.nats.client.JetStreamApiException;
+import io.nats.client.JetStreamManagement;
+import io.nats.client.api.StreamConfiguration;
+import io.nats.client.api.StreamInfo;
+
+@Component
+class StreamManager {
+
+  private static final Logger logger = LogManager.getLogger(StreamManager.class);
+
+  @Autowired
+  Properties properties;
+
+  /**
+   * This helper method created and returns a new Jetstream stream.
+   * 
+   * @category Helper method.
+   * @throws JetStreamApiException
+   * @throws IOException
+   * @return A new {@link io.nats.client.api.StreamInfo StreamInfo} object.
+   */
+  StreamInfo createNewStream(JetStreamManagement jetStreamManagement)
+      throws IOException, JetStreamApiException {
+
+    // @formatter:off
+    StreamConfiguration streamConfiguration = StreamConfiguration.builder()
+        .name(properties.getStreamName())
+        .storageType(properties.getStorageType())
+        .subjects(properties.getSubjects())
+        .replicas(properties.getReplicas())
+        .maxAge(properties.getMessageMaxAge())
+        .maxBytes(properties.getMaxBytes())
+        .maxMessages(properties.getMaxMessages())
+        .maxMsgSize(properties.getMaxMessageSize())
+        .maxConsumers(properties.getMaxConsumers())
+        .noAck(properties.getNoAcknowledgment())
+        .retentionPolicy(properties.getRetentionPolicy())
+        .discardPolicy(properties.getDiscardPolicy())
+        .duplicateWindow(properties.getDuplicateWindow())
+        .build();
+    // @formatter:on
+
+    logger.debug("Initializing a new Jetstream stream with configuration: " + streamConfiguration);
+
+    return jetStreamManagement.addStream(streamConfiguration);
+  }
+
+  StreamInfo getStreamInfo(JetStreamManagement jetStreamManagement)
+      throws IOException, JetStreamApiException {
+
+    try {
+      return jetStreamManagement.getStreamInfo(properties.getStreamName());
+    } catch (JetStreamApiException e) {
+
+      if (e.getErrorCode() == 404) {
+        return null;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  boolean streamExists(JetStreamManagement jetStreamManagement) {
+    try {
+      return getStreamInfo(jetStreamManagement) != null;
+    } catch (Exception e) {
+      logger.error("An error occurred while retrieving Jetstream stream information!", e);
+      return false;
+    }
+  }
+}

--- a/src/main/java/io/boomerang/jetstream/StreamManager.java
+++ b/src/main/java/io/boomerang/jetstream/StreamManager.java
@@ -22,6 +22,7 @@ class StreamManager {
    * This helper method creates and returns a new Jetstream stream.
    * 
    * @category Helper method.
+   * @param jetStreamManagement Jetstream management context to be used when creating a new stream.
    * @throws JetStreamApiException
    * @throws IOException
    * @return A new {@link io.nats.client.api.StreamInfo StreamInfo} object.
@@ -52,6 +53,15 @@ class StreamManager {
     return jetStreamManagement.addStream(streamConfiguration);
   }
 
+  /**
+   * This helper method returns information about a Jetstream stream.
+   * 
+   * @category Helper method.
+   * @param jetStreamManagement Jetstream management context to be used when looking up for stream.
+   * @throws JetStreamApiException
+   * @throws IOException
+   * @return Stream information. See {@link io.nats.client.api.StreamInfo StreamInfo}.
+   */
   StreamInfo getStreamInfo(JetStreamManagement jetStreamManagement)
       throws IOException, JetStreamApiException {
 
@@ -67,6 +77,13 @@ class StreamManager {
     }
   }
 
+  /**
+   * This helper method returns {@code true} if a stream exists. {@code false} otherwise.
+   * 
+   * @category Helper method.
+   * @param jetStreamManagement Jetstream management context to be used when looking up for stream.
+   * @return {@link java.lang.Boolean Boolean}.
+   */
   boolean streamExists(JetStreamManagement jetStreamManagement) {
     try {
       return getStreamInfo(jetStreamManagement) != null;

--- a/src/main/java/io/boomerang/jetstream/StreamManager.java
+++ b/src/main/java/io/boomerang/jetstream/StreamManager.java
@@ -34,7 +34,7 @@ class StreamManager {
     StreamConfiguration streamConfiguration = StreamConfiguration.builder()
         .name(properties.getStreamName())
         .storageType(properties.getStreamStorageType())
-        .subjects(properties.getStreamSubjects())
+        .subjects(properties.getStreamSubject())
         .replicas(properties.getStreamReplicas())
         .maxAge(properties.getStreamMessageMaxAge())
         .maxBytes(properties.getStreamMaxBytes())

--- a/src/main/java/io/boomerang/jetstream/StreamManager.java
+++ b/src/main/java/io/boomerang/jetstream/StreamManager.java
@@ -19,7 +19,7 @@ class StreamManager {
   Properties properties;
 
   /**
-   * This helper method created and returns a new Jetstream stream.
+   * This helper method creates and returns a new Jetstream stream.
    * 
    * @category Helper method.
    * @throws JetStreamApiException
@@ -32,18 +32,18 @@ class StreamManager {
     // @formatter:off
     StreamConfiguration streamConfiguration = StreamConfiguration.builder()
         .name(properties.getStreamName())
-        .storageType(properties.getStorageType())
-        .subjects(properties.getSubjects())
-        .replicas(properties.getReplicas())
-        .maxAge(properties.getMessageMaxAge())
-        .maxBytes(properties.getMaxBytes())
-        .maxMessages(properties.getMaxMessages())
-        .maxMsgSize(properties.getMaxMessageSize())
-        .maxConsumers(properties.getMaxConsumers())
-        .noAck(properties.getNoAcknowledgment())
-        .retentionPolicy(properties.getRetentionPolicy())
-        .discardPolicy(properties.getDiscardPolicy())
-        .duplicateWindow(properties.getDuplicateWindow())
+        .storageType(properties.getStreamStorageType())
+        .subjects(properties.getStreamSubjects())
+        .replicas(properties.getStreamReplicas())
+        .maxAge(properties.getStreamMessageMaxAge())
+        .maxBytes(properties.getStreamMaxBytes())
+        .maxMessages(properties.getStreamMaxMessages())
+        .maxMsgSize(properties.getStreamMaxMessageSize())
+        .maxConsumers(properties.getStreamMaxConsumers())
+        .noAck(properties.getStreamNoAcknowledgment())
+        .retentionPolicy(properties.getStreamRetentionPolicy())
+        .discardPolicy(properties.getStreamDiscardPolicy())
+        .duplicateWindow(properties.getStreamDuplicateWindow())
         .build();
     // @formatter:on
 

--- a/src/test/java/io/boomerang/jetstream/JetstreamClientTest.java
+++ b/src/test/java/io/boomerang/jetstream/JetstreamClientTest.java
@@ -1,0 +1,19 @@
+package io.boomerang.jetstream;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Unit test for Jetstream client.
+ */
+public class JetstreamClientTest {
+
+  /**
+   * Rigorous Test :-)
+   */
+  @Test
+  public void shouldAnswerWithTrue() {
+    assertTrue(true);
+  }
+}


### PR DESCRIPTION
Closes boomerang-io/roadmap#194

#### Changelog

**New**

- NATS Jetstream integration for:
  - Publishing a message to a stream.
  - Listening for incoming messages from a push-based consumer.
  - Listening for incoming messages from a pull-based consumer.

#### Testing/Reviewing

- Tested locally with a running NATS Jestream server ✅
- Locally with Jestream and publishing messages with `service-listener` ✅
- Locally with Jestream and listening to messages (push-based consumer) with `service-flow` ✅
- Locally with Jestream and listening to messages (pull-based consumer) with `service-flow` ✅
- Locally with Jestream, publishing messages with `service-listener` and listening to messages (pull-based consumer) with `service-flow` ✅
- E2E scenario: local Jestream server, publishing messages with `service-listener` and listening to messages (pull-based consumer) with `service-flow` and triggering Flows in OCP2 DEV ✅
- E2E scenario: remote Jetstream server, publishing messages with `service-listener` and listening to messages (pull-based consumer) with `service-flow` and triggering Flows in OCP2 DEV ❌
  - Failed test reason: error due to remote NATS Jetstream server not accepting incoming connections from outside the cluster.
